### PR TITLE
Notify via Slack message on workflow failure

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -38,3 +38,11 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Notify Slack on Failure - Ilios deployment channel
+      uses: act10ns/slack@v2
+      if: failure()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+      with:
+        status: ${{ job.status }}
+        message: Dev Deploy Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -38,3 +38,11 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Notify Slack on Failure - Ilios deployment channel
+      uses: act10ns/slack@v2
+      if: failure()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+      with:
+        status: ${{ job.status }}
+        message: Production Deploy Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -18,3 +18,11 @@ jobs:
       run: npm version major
     - name: Push Changes
       run: git push --follow-tags
+    - name: Notify Slack on Failure - Ilios deployment channel
+      uses: act10ns/slack@v2
+      if: failure()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+      with:
+        status: ${{ job.status }}
+        message: Version Tagging Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}


### PR DESCRIPTION
Followed https://github.com/ilios/frontend/pull/7727 to notify Slack on workflow failures.

Didn't add Slack notification for `auto-merge` or `ci` workflows. Slack notification added for remaining workflows: `deploy-dev`, `deploy-production`, `tag_version`.

Added `SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL` to repository secrets.