### PR TITLE
Update to AWS SDK v3

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -1,11 +1,14 @@
 import { createReadStream, createWriteStream } from 'node:fs';
-import AWS from 'aws-sdk';
 import { Logger } from './src/logger.js';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client } from '@aws-sdk/client-s3';
 import { getSurveyDetails } from './src/get-survey-details.js';
 import { getSurveyResponseSchema } from './src/get-survey-response-schema.js';
 import { getSurveyResponses } from './src/get-survey-responses.js';
 
-const s3 = new AWS.S3();
+//create the client outside of the handler:
+//https://github.com/aws/aws-sdk-js-v3?tab=readme-ov-file#best-practices
+const s3Client = new S3Client({});
 
 export async function storeSurveys(event) {
   const ids = process.env.SURVEY_IDS.split(',').filter(id => {
@@ -57,7 +60,8 @@ const storeCSVSurvey = async (surveyId, logger) => {
     Key: `${surveyId}.csv`,
     Body: createReadStream(fileName)
   };
-  await s3.upload(params).promise();
+  const command = new PutObjectCommand(params);
+  await s3Client.send(command);
   logger.addEvent('done!');
 };
 
@@ -80,7 +84,8 @@ const storeSurveyResponses = async (surveyId, logger) => {
     Key: `${surveyId}-responses.json`,
     Body: createReadStream(fileName)
   };
-  await s3.upload(params).promise();
+  const command = new PutObjectCommand(params);
+  await s3Client.send(command);
   logger.addEvent('done!');
 };
 
@@ -101,7 +106,8 @@ const storeSurveyResponseSchema = async (surveyId, logger) => {
     Key: `${surveyId}-schema.json`,
     Body: createReadStream(fileName)
   };
-  await s3.upload(params).promise();
+  const command = new PutObjectCommand(params);
+  await s3Client.send(command);
   logger.addEvent('done!');
 };
 
@@ -122,6 +128,7 @@ const storeSurveyDetails = async (surveyId, logger) => {
     Key: `${surveyId}-survey.json`,
     Body: createReadStream(fileName)
   };
-  await s3.upload(params).promise();
+  const command = new PutObjectCommand(params);
+  await s3Client.send(command);
   logger.addEvent('done!');
 };

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "author": "Jon Johnson <jon.johnson@ucsf.edu>",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.1665.0",
     "node-fetch": "^3.3.2",
     "yauzl-promise": "^2.1.3"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.621.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "serverless": "^3.38.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      aws-sdk:
-        specifier: ^2.1665.0
-        version: 2.1665.0
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -18,6 +15,9 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.621.0
+        version: 3.621.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5


### PR DESCRIPTION
Replaced the deprecated v2 calls and moved this into the dev dependencies because it is provided by lambda so we don't need to upload it ourselves.