### PR TITLE
Process Surveys One at a Time

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -16,8 +16,11 @@ export async function storeSurveys(event) {
     return Boolean(id) && typeof id === 'string' && id.length > 5;
   });
   console.log('Processing Survey Ids: ', ids);
-  const promises = ids.map(id => storeSurvey(id.trim()));
-  const loggers = await Promise.all(promises);
+
+  const loggers = [];
+  for (const id of ids) {
+    loggers.push(await storeSurvey(id.trim()));
+  }
   const output = loggers.map(logger => logger?.getEvents());
   console.log(output);
   return { message: output, event };


### PR DESCRIPTION
Using map here we were sending hundreds of survey IDs to be processed at the same time which was maxing out the number of open sockets on the node process of the lambda container. Instead process these in a loop one at a time.