### PR TITLE
Limit Timeout to 900 Seconds

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -35,7 +35,7 @@ custom:
 
 functions:
   storeSurveys:
-    timeout: 1200
+    timeout: 900
     handler: handler.storeSurveys
     events:
       - schedule:


### PR DESCRIPTION
This is the AWS max